### PR TITLE
Improve the status label text and logic on the main window

### DIFF
--- a/monitor-app/main.py
+++ b/monitor-app/main.py
@@ -48,11 +48,11 @@ def check_and_update_status(game_state, game_server_state, window):
         )
 
         if window and not window.is_minimized:
-            status_text = f"{game_name} - Game: {game_status}, Server: {server_status}"
+            status_text = f"{game_name} - Game: {'✅' if game_status == 'online' else '❌'}, Server: {'✅' if server_status == 'online' else '❌'}"
             window.update_status(status_text)
         elif window is None:
             # CLI mode
-            print(f"{game_name} - Game: {game_status}, Server: {server_status}")
+            print(f"{game_name} - Game: {'✅' if game_status == 'online' else '❌'}, Server: {'✅' if server_status == 'online' else '❌'}")
 
     except Exception as e:
         logger.error(f"Error occurred while fetching status: {e}")

--- a/monitor-app/main.py
+++ b/monitor-app/main.py
@@ -48,11 +48,12 @@ def check_and_update_status(game_state, game_server_state, window):
         )
 
         if window and not window.is_minimized:
-            status_text = f"{game_name} - Game: {'✅' if game_status == 'online' else '❌'}, Server: {'✅' if server_status == 'online' else '❌'}"
+            status_text = (f"{game_name} \nGame: {'Online ✅' if game_status == 'online' else 'Offline ❌ '}"
+                           f"\n Server: {'Online ✅' if server_status == 'online' else 'Offline ❌'}")
             window.update_status(status_text)
         elif window is None:
             # CLI mode
-            print(f"{game_name} - Game: {'✅' if game_status == 'online' else '❌'}, Server: {'✅' if server_status == 'online' else '❌'}")
+            print(f"{game_name} - Game: {game_status}, Server: {server_status}")
 
     except Exception as e:
         logger.error(f"Error occurred while fetching status: {e}")

--- a/monitor-app/src/core/constants.py
+++ b/monitor-app/src/core/constants.py
@@ -14,3 +14,7 @@ RED_CIRCLE = "🔴"
 # Steam API URLs
 STEAM_API_URL = "https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2/"
 STEAM_STORE_API_URL = "https://store.steampowered.com/api/appdetails"
+
+# Emojis for online and offline status
+ONLINE_EMOJI = "✅"
+OFFLINE_EMOJI = "❌"

--- a/monitor-app/src/gui/mainwindow.py
+++ b/monitor-app/src/gui/mainwindow.py
@@ -12,6 +12,8 @@ from src.gui.utils.gui_config import gui_config
 from ..core.logger import logger
 from src.gui.utils.gui_utils import get_current_theme, is_linux
 from src.gui.utils.app_settings import AppSettings
+from src.core.constants import CHECK_INTERVAL
+
 
 class MainWindow(QMainWindow):
     is_minimized = False
@@ -50,12 +52,17 @@ class MainWindow(QMainWindow):
 
         self.theme_changed.connect(self.update_theme)
 
+        self.status_timeout_timer = QTimer(self)
+        self.status_timeout_timer.timeout.connect(self.handle_status_timeout)
+        self.status_timeout_timer.setSingleShot(True)
+
         logger.info("MainWindow initialized")
 
     def open_settings_dialog(self):
         dialog = SettingsDialog(self)
         if dialog.exec():
             logger.info("Settings updated")
+
     def set_window_icon(self):
         icon = QIcon(gui_config.WINDOW_ICON_PNG)
         self.setWindowIcon(icon)
@@ -83,8 +90,12 @@ class MainWindow(QMainWindow):
         if not self.is_minimized:
             logger.debug(f"Updating status: {status}")
             self.status_label.setText(status)
+            self.status_timeout_timer.start(CHECK_INTERVAL * 1000)
         else:
             logger.debug(f"Skipping status update while minimized: {status}")
+
+    def handle_status_timeout(self):
+        self.status_label.setText("Error encountered")
 
     def closeEvent(self, event):
         event.ignore()

--- a/monitor-app/src/gui/mainwindow.py
+++ b/monitor-app/src/gui/mainwindow.py
@@ -37,7 +37,7 @@ class MainWindow(QMainWindow):
         layout = QVBoxLayout()
         central_widget.setLayout(layout)
 
-        self.status_label = QLabel("Initializing...")
+        self.status_label = QLabel()
         self.status_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.status_label.setWordWrap(True)
         self.status_label.setFont(QFont(gui_config.FONT_FAMILY, gui_config.FONT_SIZE_LARGE))
@@ -57,6 +57,9 @@ class MainWindow(QMainWindow):
         self.status_timeout_timer.setSingleShot(True)
 
         logger.info("MainWindow initialized")
+
+        # Initialize the app with a status message
+        self.update_status("Initializing...")
 
     def open_settings_dialog(self):
         dialog = SettingsDialog(self)
@@ -87,15 +90,14 @@ class MainWindow(QMainWindow):
         self.exit_app.emit()
 
     def update_status(self, status):
+        logger.debug(f"Updating status: {status}")
         if not self.is_minimized:
-            logger.debug(f"Updating status: {status}")
             self.status_label.setText(status)
             self.status_timeout_timer.start(CHECK_INTERVAL * 1000)
-        else:
-            logger.debug(f"Skipping status update while minimized: {status}")
 
     def handle_status_timeout(self):
-        self.status_label.setText("Error encountered")
+        logger.warning("Status update timeout")
+        self.status_label.setText("Error encountered: Status update timeout")
 
     def closeEvent(self, event):
         event.ignore()
@@ -105,7 +107,7 @@ class MainWindow(QMainWindow):
             self.tray_icon.showMessage(
                 AppSettings.APP_NAME,
                 "Application minimized to tray",
-                QSystemTrayIcon.Information,
+                QSystemTrayIcon.MessageIcon.Information,
                 2000
             )
 

--- a/monitor-app/src/gui/mainwindow.py
+++ b/monitor-app/src/gui/mainwindow.py
@@ -92,12 +92,15 @@ class MainWindow(QMainWindow):
     def update_status(self, status):
         logger.debug(f"Updating status: {status}")
         if not self.is_minimized:
+            # Stop any existing timer before starting a new one
+            self.status_timeout_timer.stop()
             self.status_label.setText(status)
-            self.status_timeout_timer.start(CHECK_INTERVAL * 1000)
+            # Start a new timeout timer with double the check interval
+            self.status_timeout_timer.start(CHECK_INTERVAL * 1000 * 2)
 
     def handle_status_timeout(self):
         logger.warning("Status update timeout")
-        self.status_label.setText("Error encountered: Status update timeout")
+        self.status_label.setText("Error: No updates")
 
     def closeEvent(self, event):
         event.ignore()


### PR DESCRIPTION
Fixes #61

Add timeout mechanism and status emojis to the main window.

* Add a timeout mechanism for the status text in the `MainWindow` class in `monitor-app/src/gui/mainwindow.py`.
* Update the `update_status` method in `MainWindow` to include emojis for online (✅) and offline (❌) status.
* Add a `handle_status_timeout` method in `MainWindow` to reset the status text to "Error encountered" after the timeout.
* Update the `check_and_update_status` function in `monitor-app/main.py` to include emojis for online and offline status.
* Add constants for online and offline emojis in `monitor-app/src/core/constants.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bl4ckswordsman/disco-beacon/issues/61?shareId=54b3f3ce-5a11-4e39-909c-dc8ce0afe81a).