### PR TITLE
Remove unused python-dotenv dependency

### DIFF
--- a/monitor-app/requirements.txt
+++ b/monitor-app/requirements.txt
@@ -1,4 +1,3 @@
 PySide6==6.8.0.2
 requests==2.32.3
-python-dotenv==1.0.1
 pyinstaller==6.11.0


### PR DESCRIPTION
Fixes #66

Remove the `python-dotenv` dependency from `monitor-app/requirements.txt`.

* Remove the `python-dotenv` dependency as it is not used or needed in the codebase.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bl4ckswordsman/disco-beacon/pull/67?shareId=39dde337-d8e6-4d25-8dcc-f9704e36032f).