### PR TITLE
feat: Add Mica transparency to Windows build

### DIFF
--- a/monitor-app/main.py
+++ b/monitor-app/main.py
@@ -7,6 +7,9 @@ from src.core.state import GameState, GameServerState
 from src.gui.utils.gui_init import init_gui
 from src.gui.utils.app_settings import AppSettings
 from src.core.app_settings import app_settings
+from PySide6.QtCore import QOperatingSystemVersion, QApplication
+from src.gui.utils.mica_transparency import enable_mica_transparency
+
 gui_available = False
 
 try:
@@ -78,6 +81,8 @@ def main() -> None:
     if gui_available:
         logger.info("Running in GUI mode")
         app, window, tray_icon = init_gui()
+        if QOperatingSystemVersion.current() == QOperatingSystemVersion.Windows11:
+            enable_mica_transparency()
         try:
             while True:
                 current_time = time.time()

--- a/monitor-app/src/gui/mainwindow.py
+++ b/monitor-app/src/gui/mainwindow.py
@@ -1,6 +1,6 @@
 try:
     from PySide6.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QLabel, QSystemTrayIcon, QPushButton
-    from PySide6.QtCore import Qt, Signal, QTimer
+    from PySide6.QtCore import Qt, Signal, QTimer, QOperatingSystemVersion
     from PySide6.QtGui import QIcon, QFont
 except ImportError:
     from PyQt6.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QLabel, QSystemTrayIcon, QPushButton
@@ -13,6 +13,7 @@ from ..core.logger import logger
 from src.gui.utils.gui_utils import get_current_theme, is_linux
 from src.gui.utils.app_settings import AppSettings
 from src.core.constants import CHECK_INTERVAL
+from src.gui.utils.mica_transparency import enable_mica_transparency
 
 
 class MainWindow(QMainWindow):
@@ -60,6 +61,9 @@ class MainWindow(QMainWindow):
 
         # Initialize the app with a status message
         self.update_status("Initializing...")
+
+        if QOperatingSystemVersion.current() == QOperatingSystemVersion.Windows11:
+            enable_mica_transparency()
 
     def open_settings_dialog(self):
         dialog = SettingsDialog(self)

--- a/monitor-app/src/gui/utils/gui_config.py
+++ b/monitor-app/src/gui/utils/gui_config.py
@@ -24,4 +24,6 @@ class GUIConfig:
         'offline': Qt.red
     }
 
+    WINDOWS_11_VERSION = Qt.QOperatingSystemVersion.Windows11
+
 gui_config = GUIConfig()

--- a/monitor-app/src/gui/utils/gui_init.py
+++ b/monitor-app/src/gui/utils/gui_init.py
@@ -5,6 +5,8 @@ from src.gui.system_tray import SystemTrayIcon
 from src.core.logger import logger
 import resources.resources # noqa: F401
 from src.gui.utils.gui_utils import get_current_theme
+from PySide6.QtCore import QOperatingSystemVersion
+from src.gui.utils.mica_transparency import enable_mica_transparency
 
 def init_gui():
     # import os
@@ -24,6 +26,9 @@ def init_gui():
 
     # Set the tray icon for the main window
     window.set_tray_icon(tray_icon)
+
+    if QOperatingSystemVersion.current() == QOperatingSystemVersion.Windows11:
+        enable_mica_transparency()
 
     logger.info("GUI initialized with system tray icon and Fusion style")
     return app, window, tray_icon

--- a/monitor-app/src/gui/utils/gui_utils.py
+++ b/monitor-app/src/gui/utils/gui_utils.py
@@ -18,3 +18,6 @@ def get_icon_path(theme: str) -> str:
 
 def is_linux():
     return platform.system() == 'Linux'
+
+def is_windows_11():
+    return platform.system() == 'Windows' and platform.release() == '10' and int(platform.version().split('.')[2]) >= 22000

--- a/monitor-app/src/gui/utils/mica_transparency.py
+++ b/monitor-app/src/gui/utils/mica_transparency.py
@@ -16,6 +16,7 @@ class WINDOWCOMPOSITIONATTRIBDATA(ctypes.Structure):
         ('SizeOfData', ctypes.c_size_t)
     ]
 
+
 WCA_ACCENT_POLICY = 19
 ACCENT_ENABLE_BLURBEHIND = 3
 

--- a/monitor-app/src/gui/utils/mica_transparency.py
+++ b/monitor-app/src/gui/utils/mica_transparency.py
@@ -16,7 +16,6 @@ class WINDOWCOMPOSITIONATTRIBDATA(ctypes.Structure):
         ('SizeOfData', ctypes.c_size_t)
     ]
 
-
 WCA_ACCENT_POLICY = 19
 ACCENT_ENABLE_BLURBEHIND = 3
 

--- a/monitor-app/src/gui/utils/mica_transparency.py
+++ b/monitor-app/src/gui/utils/mica_transparency.py
@@ -1,0 +1,33 @@
+import ctypes
+from ctypes import wintypes
+
+class ACCENT_POLICY(ctypes.Structure):
+    _fields_ = [
+        ('AccentState', ctypes.c_int),
+        ('AccentFlags', ctypes.c_int),
+        ('GradientColor', ctypes.c_int),
+        ('AnimationId', ctypes.c_int)
+    ]
+
+class WINDOWCOMPOSITIONATTRIBDATA(ctypes.Structure):
+    _fields_ = [
+        ('Attribute', ctypes.c_int),
+        ('Data', ctypes.POINTER(ACCENT_POLICY)),
+        ('SizeOfData', ctypes.c_size_t)
+    ]
+
+WCA_ACCENT_POLICY = 19
+ACCENT_ENABLE_BLURBEHIND = 3
+
+def enable_mica_transparency():
+    accent_policy = ACCENT_POLICY()
+    accent_policy.AccentState = ACCENT_ENABLE_BLURBEHIND
+    accent_policy.GradientColor = 0x00FFFFFF  # White with full transparency
+
+    data = WINDOWCOMPOSITIONATTRIBDATA()
+    data.Attribute = WCA_ACCENT_POLICY
+    data.Data = ctypes.pointer(accent_policy)
+    data.SizeOfData = ctypes.sizeof(accent_policy)
+
+    hwnd = ctypes.windll.user32.GetForegroundWindow()
+    ctypes.windll.user32.SetWindowCompositionAttribute(hwnd, ctypes.byref(data))


### PR DESCRIPTION
Fixes #68

Add native Mica Windows 11 transparency to the PySide6 Windows build of the app.

* **Main Application**:
  - Import `enable_mica_transparency` from `src.gui.utils.mica_transparency` in `monitor-app/main.py`.
  - Call `enable_mica_transparency` function in the `main` function if running on Windows 11.

* **Main Window**:
  - Import `enable_mica_transparency` from `src.gui.utils.mica_transparency` in `monitor-app/src/gui/mainwindow.py`.
  - Call `enable_mica_transparency` function in the `MainWindow` constructor if running on Windows 11.

* **GUI Configuration**:
  - Add constant `WINDOWS_11_VERSION` to represent Windows 11 version in `monitor-app/src/gui/utils/gui_config.py`.

* **GUI Initialization**:
  - Import `enable_mica_transparency` from `src.gui.utils.mica_transparency` in `monitor-app/src/gui/utils/gui_init.py`.
  - Call `enable_mica_transparency` function in the `init_gui` function if running on Windows 11.

* **Utility Functions**:
  - Add function `is_windows_11` to check if the operating system is Windows 11 in `monitor-app/src/gui/utils/gui_utils.py`.

* **New File**:
  - Add `monitor-app/src/gui/utils/mica_transparency.py` with the function `enable_mica_transparency` to enable Mica transparency for Windows 11.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bl4ckswordsman/disco-beacon/pull/69?shareId=76b6fbbf-dd60-4638-a33f-f53872fa09f9).