### PR TITLE
feat: Add build version to the Windows build

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -29,6 +29,9 @@ jobs:
         run: |
           $env:VERSION = $env:GITHUB_REF -replace 'refs/tags/v', ''
           echo "VERSION=$env:VERSION" >> $env:GITHUB_ENV
+      - name: Set build version
+        run: |
+          echo "BUILD_VERSION=$env:VERSION" >> $env:GITHUB_ENV
       - name: Create archive
         run: |
           Compress-Archive -Path .\dist\DiscoBeacon.exe -DestinationPath .\DiscoBeacon_Windows_$env:VERSION.zip
@@ -71,6 +74,9 @@ jobs:
       - name: Set VERSION
         run: |
           echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+      - name: Set build version
+        run: |
+          echo "BUILD_VERSION=${VERSION}" >> $GITHUB_ENV
       - name: Create archive
         run: |
           tar -czvf ./DiscoBeacon_Linux_${VERSION}.tar.gz -C ./dist DiscoBeacon

--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -29,9 +29,6 @@ jobs:
         run: |
           $env:VERSION = $env:GITHUB_REF -replace 'refs/tags/v', ''
           echo "VERSION=$env:VERSION" >> $env:GITHUB_ENV
-      - name: Set build version
-        run: |
-          echo "BUILD_VERSION=$env:VERSION" >> $env:GITHUB_ENV
       - name: Create archive
         run: |
           Compress-Archive -Path .\dist\DiscoBeacon.exe -DestinationPath .\DiscoBeacon_Windows_$env:VERSION.zip
@@ -74,9 +71,6 @@ jobs:
       - name: Set VERSION
         run: |
           echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
-      - name: Set build version
-        run: |
-          echo "BUILD_VERSION=${VERSION}" >> $GITHUB_ENV
       - name: Create archive
         run: |
           tar -czvf ./DiscoBeacon_Linux_${VERSION}.tar.gz -C ./dist DiscoBeacon

--- a/.github/workflows/test_build_windows.yaml
+++ b/.github/workflows/test_build_windows.yaml
@@ -21,19 +21,21 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pillow
+      - name: Set test version
+        run: |
+          $timestamp = Get-Date -Format "yyyyMMdd-HHmm"
+          # Read version from version.py and append timestamp
+          $version = (Get-Content version.py | Select-String 'VERSION = "(.*)"').Matches.Groups[1].Value
+          $testVersion = "$version-test-$timestamp"
+          echo "VERSION=$testVersion" >> $env:GITHUB_ENV
+          # Update version.py with test version
+          (Get-Content version.py) -replace 'VERSION = ".*"', "VERSION = `"$testVersion`"" | Set-Content version.py
       - name: Build executable
         run: |
           pyinstaller --clean disco_beacon.spec
-      - name: Set VERSION
-        run: |
-          $env:VERSION = $env:GITHUB_REF -replace 'refs/tags/v', ''
-          echo "VERSION=$env:VERSION" >> $env:GITHUB_ENV
-      - name: Set build version
-        run: |
-          echo "BUILD_VERSION=$env:VERSION" >> $env:GITHUB_ENV
       - name: Upload test artifact
         uses: actions/upload-artifact@v4
         with:
-          name: DiscoBeacon_Windows_Test
+          name: DiscoBeacon_Windows_Test_${{ env.VERSION }}
           path: ${{ github.workspace }}/monitor-app/dist/DiscoBeacon.exe
           retention-days: 5

--- a/.github/workflows/test_build_windows.yaml
+++ b/.github/workflows/test_build_windows.yaml
@@ -23,7 +23,7 @@ jobs:
           pip install pillow
       - name: Set test version
         run: |
-          $timestamp = Get-Date -Format "yyyyMMdd-HHmm"
+          $timestamp = [System.TimeZoneInfo]::ConvertTimeBySystemTimeZoneId((Get-Date), 'Central European Standard Time').ToString("yyyyMMdd-HHmm")
           # Read version from version.py and append timestamp
           $version = (Get-Content version.py | Select-String 'VERSION = "(.*)"').Matches.Groups[1].Value
           $testVersion = "$version-test-$timestamp"

--- a/.github/workflows/test_build_windows.yaml
+++ b/.github/workflows/test_build_windows.yaml
@@ -24,6 +24,13 @@ jobs:
       - name: Build executable
         run: |
           pyinstaller --clean disco_beacon.spec
+      - name: Set VERSION
+        run: |
+          $env:VERSION = $env:GITHUB_REF -replace 'refs/tags/v', ''
+          echo "VERSION=$env:VERSION" >> $env:GITHUB_ENV
+      - name: Set build version
+        run: |
+          echo "BUILD_VERSION=$env:VERSION" >> $env:GITHUB_ENV
       - name: Upload test artifact
         uses: actions/upload-artifact@v4
         with:

--- a/monitor-app/disco_beacon.spec
+++ b/monitor-app/disco_beacon.spec
@@ -14,7 +14,6 @@ png_icon_path = os.path.join('icons', 'tower-control.png')
 icons_dir = 'icons'
 
 a = Analysis(
-    version='version.py:VERSION',
     ['main.py'],
     pathex=[],
     binaries=[],
@@ -44,6 +43,7 @@ exe = EXE(
     a.datas,
     [],
     name='DiscoBeacon',
+    version_file=None,  # Version info from version.py will be shown in the app
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
@@ -89,6 +89,7 @@ if platform.system() == "Windows":
         a_windows.datas,
         [],
         name='DiscoBeacon',
+        version_file=None,  # Version info from version.py will be shown in the app
         debug=False,
         bootloader_ignore_signals=False,
         strip=False,

--- a/monitor-app/disco_beacon.spec
+++ b/monitor-app/disco_beacon.spec
@@ -14,6 +14,7 @@ png_icon_path = os.path.join('icons', 'tower-control.png')
 icons_dir = 'icons'
 
 a = Analysis(
+    version='version.py:VERSION',
     ['main.py'],
     pathex=[],
     binaries=[],

--- a/monitor-app/main.py
+++ b/monitor-app/main.py
@@ -7,7 +7,6 @@ from src.core.state import GameState, GameServerState
 from src.gui.utils.gui_init import init_gui
 from src.gui.utils.app_settings import AppSettings
 from src.core.app_settings import app_settings
-from version import __version__
 
 gui_available = False
 
@@ -64,7 +63,6 @@ def check_and_update_status(game_state, game_server_state, window):
 def setup_application():
     if gui_available:
         AppSettings.set_app_metadata()
-        app_settings.set('build_version', __version__)
     logger.info("Application setup completed")
 
 def main() -> None:

--- a/monitor-app/main.py
+++ b/monitor-app/main.py
@@ -7,6 +7,7 @@ from src.core.state import GameState, GameServerState
 from src.gui.utils.gui_init import init_gui
 from src.gui.utils.app_settings import AppSettings
 from src.core.app_settings import app_settings
+from version import __version__
 
 gui_available = False
 
@@ -63,6 +64,7 @@ def check_and_update_status(game_state, game_server_state, window):
 def setup_application():
     if gui_available:
         AppSettings.set_app_metadata()
+        app_settings.set('build_version', __version__)
     logger.info("Application setup completed")
 
 def main() -> None:

--- a/monitor-app/src/gui/settings_dialog.py
+++ b/monitor-app/src/gui/settings_dialog.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QFormLayout, QLineEdit, QSpinBox, QPushButton, QComboBox
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QFormLayout, QLineEdit, QSpinBox, QPushButton, QComboBox, QLabel
 from PySide6.QtCore import Signal
 from src.core.app_settings import app_settings
 from src.core import constants
@@ -41,6 +41,9 @@ class SettingsDialog(QDialog):
         self.monitor_mode.setCurrentText(app_settings.get('monitor_mode', 'Both'))
         form_layout.addRow("Monitor Mode:", self.monitor_mode)
 
+        self.build_version_label = QLabel(f"Build Version: {app_settings.get('build_version', 'N/A')}")
+        form_layout.addRow("Build Version:", self.build_version_label)
+
         self.layout.addLayout(form_layout)
 
         save_button = QPushButton("Save")
@@ -54,4 +57,5 @@ class SettingsDialog(QDialog):
         app_settings.set('check_interval', self.check_interval.value())
         app_settings.set('game_app_id', [k for k, v in constants.SUPPORTED_GAMES.items() if v == self.game_selector.currentText()][0])
         app_settings.set('monitor_mode', self.monitor_mode.currentText().lower())
+        app_settings.set('build_version', self.build_version_label.text().split(": ")[1])
         self.accept()

--- a/monitor-app/src/gui/settings_dialog.py
+++ b/monitor-app/src/gui/settings_dialog.py
@@ -1,5 +1,6 @@
 from PySide6.QtWidgets import QDialog, QVBoxLayout, QFormLayout, QLineEdit, QSpinBox, QPushButton, QComboBox, QLabel
-from PySide6.QtCore import Signal
+from PySide6.QtCore import Signal, Qt
+from version import __version__
 from src.core.app_settings import app_settings
 from src.core import constants
 from src.gui.utils.platform_utils import is_windows_11
@@ -41,14 +42,22 @@ class SettingsDialog(QDialog):
         self.monitor_mode.setCurrentText(app_settings.get('monitor_mode', 'Both'))
         form_layout.addRow("Monitor Mode:", self.monitor_mode)
 
-        self.build_version_label = QLabel(f"Build Version: {app_settings.get('build_version', 'N/A')}")
-        form_layout.addRow("Build Version:", self.build_version_label)
-
         self.layout.addLayout(form_layout)
 
         save_button = QPushButton("Save")
         save_button.clicked.connect(self.save_settings)
         self.layout.addWidget(save_button)
+
+        # Add build version at bottom with styling
+        self.build_version_label = QLabel(f"Version {__version__}")
+        self.build_version_label.setStyleSheet("""
+            QLabel {
+                font-size: 9pt;
+                padding: 5px;
+            }
+        """)
+        self.build_version_label.setAlignment(Qt.AlignmentFlag.AlignRight)
+        self.layout.addWidget(self.build_version_label)
 
     def save_settings(self):
         app_settings.set('webhook_url', self.webhook_url.text())
@@ -57,5 +66,4 @@ class SettingsDialog(QDialog):
         app_settings.set('check_interval', self.check_interval.value())
         app_settings.set('game_app_id', [k for k, v in constants.SUPPORTED_GAMES.items() if v == self.game_selector.currentText()][0])
         app_settings.set('monitor_mode', self.monitor_mode.currentText().lower())
-        app_settings.set('build_version', self.build_version_label.text().split(": ")[1])
         self.accept()

--- a/monitor-app/src/gui/utils/app_settings.py
+++ b/monitor-app/src/gui/utils/app_settings.py
@@ -16,3 +16,7 @@ class AppSettings:
     @classmethod
     def get_app_icon(cls):
         return QIcon(cls.ICON_PATH)
+
+    @classmethod
+    def get_build_version(cls):
+        return QCoreApplication.applicationVersion()

--- a/monitor-app/version.py
+++ b/monitor-app/version.py
@@ -1,6 +1,3 @@
-import os
+VERSION = "0.0.1-hotfix2"
 
-def get_version():
-    return os.getenv('VERSION', '0.0.1')
-
-__version__ = get_version()
+__version__ = VERSION

--- a/monitor-app/version.py
+++ b/monitor-app/version.py
@@ -1,1 +1,6 @@
-__version__ = "0.0.1" # Pre-release version
+import os
+
+def get_version():
+    return os.getenv('VERSION', '0.0.1')
+
+__version__ = get_version()


### PR DESCRIPTION
Fixes #56

Add build version display and setting logic for Windows and Linux builds.

* Add a new label to display the build version in the `SettingsDialog` class in `monitor-app/src/gui/settings_dialog.py`.
* Update the `save_settings` method in `monitor-app/src/gui/settings_dialog.py` to save the build version.
* Add a new method to get the build version in `monitor-app/src/gui/utils/app_settings.py`.
* Import the `__version__` from `version.py` and set the build version in the `setup_application` function in `monitor-app/main.py`.
* Update `__version__` to be dynamically set based on the build version in `monitor-app/version.py`.
* Add steps to set the build version for both Windows and Linux builds in `.github/workflows/build_and_release.yaml`.
* Add steps to set the build version for the Windows build in `.github/workflows/test_build_windows.yaml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bl4ckswordsman/disco-beacon/pull/72?shareId=e0b2c9f9-a9a8-4107-9a06-4935adc74433).