### PR TITLE
feat: Add GitHub update checker

### DIFF
--- a/monitor-app/main.py
+++ b/monitor-app/main.py
@@ -8,6 +8,7 @@ from src.gui.utils.gui_init import init_gui
 from src.gui.utils.app_settings import AppSettings
 from src.core.app_settings import settings_loader, settings_saver, handle_autorun_change
 from src.gui.utils.platform_utils import is_windows
+from src.core.version_checker import fetch_latest_version, compare_versions
 
 gui_available = False
 
@@ -81,6 +82,16 @@ def initialize_application():
         if not handle_autorun_change(auto_run_enabled):
             settings_saver.set_setting('auto_run', False)
 
+def check_for_updates():
+    latest_version = fetch_latest_version()
+    if latest_version:
+        comparison_result = compare_versions(AppSettings.VERSION, latest_version)
+        if "new version" in comparison_result:
+            logger.info(comparison_result)
+            if gui_available:
+                from PySide6.QtWidgets import QMessageBox
+                QMessageBox.information(None, "Update Available", comparison_result)
+
 def main() -> None:
     logger.info("Application starting")
 
@@ -95,6 +106,7 @@ def main() -> None:
     if gui_available:
         logger.info("Running in GUI mode")
         app, window, tray_icon = init_gui()
+        check_for_updates()
         try:
             while True:
                 current_time = time.time()

--- a/monitor-app/main.py
+++ b/monitor-app/main.py
@@ -82,15 +82,20 @@ def initialize_application():
         if not handle_autorun_change(auto_run_enabled):
             settings_saver.set_setting('auto_run', False)
 
-def check_for_updates():
+def check_for_updates(tray_icon=None):
     latest_version = fetch_latest_version()
     if latest_version:
         comparison_result = compare_versions(AppSettings.VERSION, latest_version)
-        if "new version" in comparison_result:
+        if "→" in comparison_result:
             logger.info(comparison_result)
-            if gui_available:
-                from PySide6.QtWidgets import QMessageBox
-                QMessageBox.information(None, "Update Available", comparison_result)
+            if gui_available and tray_icon:
+                from PySide6.QtWidgets import QSystemTrayIcon
+                tray_icon.showMessage(
+                    "Update Available",
+                    comparison_result,
+                    QSystemTrayIcon.MessageIcon.Information,
+                    5000  # Show for 5 seconds
+                )
 
 def main() -> None:
     logger.info("Application starting")
@@ -106,7 +111,7 @@ def main() -> None:
     if gui_available:
         logger.info("Running in GUI mode")
         app, window, tray_icon = init_gui()
-        check_for_updates()
+        check_for_updates(tray_icon)
         try:
             while True:
                 current_time = time.time()

--- a/monitor-app/src/core/version_checker.py
+++ b/monitor-app/src/core/version_checker.py
@@ -8,13 +8,22 @@ def fetch_latest_version():
         response = requests.get(GITHUB_API_URL)
         response.raise_for_status()
         latest_release = response.json()
-        return latest_release["tag_name"]
+        # Strip 'v' prefix if present to ensure consistent comparison
+        return latest_release["tag_name"].lstrip('v')
     except requests.RequestException as e:
         print(f"Error fetching latest version: {e}")
         return None
 
 def compare_versions(current_version, latest_version):
-    if current_version == latest_version:
+    # Strip 'v' prefix if present
+    current = current_version.lstrip('v')
+    latest = latest_version.lstrip('v')
+
+    # Convert version strings to tuples of integers for proper comparison
+    current_parts = tuple(map(int, current.split('.')))
+    latest_parts = tuple(map(int, latest.split('.')))
+
+    if current_parts >= latest_parts:
         return "You are using the latest version."
     else:
         return f"A new version ({latest_version}) is available. Please update."

--- a/monitor-app/src/core/version_checker.py
+++ b/monitor-app/src/core/version_checker.py
@@ -1,5 +1,4 @@
 import requests
-from src.version import __version__
 
 GITHUB_API_URL = "https://api.github.com/repos/bl4ckswordsman/disco-beacon/releases/latest"
 
@@ -24,6 +23,6 @@ def compare_versions(current_version, latest_version):
     latest_parts = tuple(map(int, latest.split('.')))
 
     if current_parts >= latest_parts:
-        return "You are using the latest version."
+        return f"v{current} (Latest ✅)"
     else:
-        return f"A new version ({latest_version}) is available. Please update."
+        return f"Update available: v{current} → v{latest}"

--- a/monitor-app/src/core/version_checker.py
+++ b/monitor-app/src/core/version_checker.py
@@ -1,0 +1,20 @@
+import requests
+from src.version import __version__
+
+GITHUB_API_URL = "https://api.github.com/repos/bl4ckswordsman/disco-beacon/releases/latest"
+
+def fetch_latest_version():
+    try:
+        response = requests.get(GITHUB_API_URL)
+        response.raise_for_status()
+        latest_release = response.json()
+        return latest_release["tag_name"]
+    except requests.RequestException as e:
+        print(f"Error fetching latest version: {e}")
+        return None
+
+def compare_versions(current_version, latest_version):
+    if current_version == latest_version:
+        return "You are using the latest version."
+    else:
+        return f"A new version ({latest_version}) is available. Please update."

--- a/monitor-app/src/gui/settings_dialog.py
+++ b/monitor-app/src/gui/settings_dialog.py
@@ -6,6 +6,8 @@ from src.core.app_settings import settings_loader, settings_saver, handle_autoru
 from src.core import constants
 from src.gui.utils.platform_utils import is_windows_11, is_windows
 from src.gui.utils.mica_utils import apply_mica_to_window
+from src.core.version_checker import fetch_latest_version, compare_versions
+import webbrowser
 
 class SettingsDialog(QDialog):
     theme_changed = Signal(str)
@@ -74,6 +76,35 @@ class SettingsDialog(QDialog):
         """)
         self.build_version_label.setAlignment(Qt.AlignmentFlag.AlignRight)
         self.layout.addWidget(self.build_version_label)
+
+        # Add latest version label
+        self.latest_version_label = QLabel("Fetching latest version...")
+        self.latest_version_label.setStyleSheet("""
+            QLabel {
+                font-size: 9pt;
+                padding: 5px;
+            }
+        """)
+        self.latest_version_label.setAlignment(Qt.AlignmentFlag.AlignRight)
+        self.layout.addWidget(self.latest_version_label)
+
+        # Add button to open latest release page
+        self.release_button = QPushButton("Go to Latest Release")
+        self.release_button.clicked.connect(self.open_latest_release_page)
+        self.layout.addWidget(self.release_button)
+
+        self.fetch_and_compare_versions()
+
+    def fetch_and_compare_versions(self):
+        latest_version = fetch_latest_version()
+        if latest_version:
+            comparison_result = compare_versions(__version__, latest_version)
+            self.latest_version_label.setText(f"Latest Version: {latest_version}\n{comparison_result}")
+        else:
+            self.latest_version_label.setText("Failed to fetch latest version")
+
+    def open_latest_release_page(self):
+        webbrowser.open("https://github.com/bl4ckswordsman/disco-beacon/releases/latest")
 
     def save_settings(self):
         # Save all non-autorun settings first

--- a/monitor-app/src/gui/settings_dialog.py
+++ b/monitor-app/src/gui/settings_dialog.py
@@ -1,6 +1,6 @@
-from PySide6.QtWidgets import (QDialog, QVBoxLayout, QFormLayout, QLineEdit,
+from PySide6.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QFormLayout, QLineEdit,
     QSpinBox, QPushButton, QComboBox, QLabel, QCheckBox, QFrame)
-from PySide6.QtCore import Signal, Qt
+from PySide6.QtCore import Signal
 from src.version import __version__
 from src.core.app_settings import settings_loader, settings_saver, handle_autorun_change
 from src.core import constants
@@ -72,32 +72,29 @@ class SettingsDialog(QDialog):
         separator.setFrameShadow(QFrame.Shadow.Sunken)
         self.layout.addWidget(separator)
 
-        # Add build version at bottom with styling
-        self.build_version_label = QLabel(f"Version {__version__}")
-        self.build_version_label.setStyleSheet("""
-            QLabel {
+        # Create horizontal layout for version info
+        version_layout = QHBoxLayout()
+
+        # Version label
+        self.version_label = QLabel("Checking for updates...")
+        self.version_label.setStyleSheet("font-size: 9pt;")
+        version_layout.addWidget(self.version_label)
+
+        # Update button (smaller than regular buttons)
+        self.update_button = QPushButton("View Update")
+        self.update_button.setStyleSheet("""
+            QPushButton {
                 font-size: 9pt;
-                padding: 5px;
+                padding: 2px 8px;
+                max-height: 20px;
             }
         """)
-        self.build_version_label.setAlignment(Qt.AlignmentFlag.AlignRight)
-        self.layout.addWidget(self.build_version_label)
+        self.update_button.clicked.connect(self.open_latest_release_page)
+        self.update_button.hide()  # Hidden by default until update is available
+        version_layout.addWidget(self.update_button)
 
-        # Add latest version label
-        self.latest_version_label = QLabel("Fetching latest version...")
-        self.latest_version_label.setStyleSheet("""
-            QLabel {
-                font-size: 9pt;
-                padding: 5px;
-            }
-        """)
-        self.latest_version_label.setAlignment(Qt.AlignmentFlag.AlignRight)
-        self.layout.addWidget(self.latest_version_label)
-
-        # Add button to open latest release page
-        self.release_button = QPushButton("Go to Latest Release")
-        self.release_button.clicked.connect(self.open_latest_release_page)
-        self.layout.addWidget(self.release_button)
+        version_layout.addStretch()  # Push everything to the left
+        self.layout.addLayout(version_layout)
 
         self.fetch_and_compare_versions()
 
@@ -105,9 +102,12 @@ class SettingsDialog(QDialog):
         latest_version = fetch_latest_version()
         if latest_version:
             comparison_result = compare_versions(__version__, latest_version)
-            self.latest_version_label.setText(f"Latest Version: {latest_version}\n{comparison_result}")
+            self.version_label.setText(comparison_result)
+            # Show update button only if newer version is available
+            if "→" in comparison_result:
+                self.update_button.show()
         else:
-            self.latest_version_label.setText("Failed to fetch latest version")
+            self.version_label.setText("Version check failed")
 
     def open_latest_release_page(self):
         webbrowser.open("https://github.com/bl4ckswordsman/disco-beacon/releases/latest")

--- a/monitor-app/src/gui/settings_dialog.py
+++ b/monitor-app/src/gui/settings_dialog.py
@@ -1,5 +1,5 @@
 from PySide6.QtWidgets import (QDialog, QVBoxLayout, QFormLayout, QLineEdit,
-    QSpinBox, QPushButton, QComboBox, QLabel, QCheckBox)
+    QSpinBox, QPushButton, QComboBox, QLabel, QCheckBox, QFrame)
 from PySide6.QtCore import Signal, Qt
 from src.version import __version__
 from src.core.app_settings import settings_loader, settings_saver, handle_autorun_change
@@ -65,6 +65,12 @@ class SettingsDialog(QDialog):
         save_button = QPushButton("Save")
         save_button.clicked.connect(self.save_settings)
         self.layout.addWidget(save_button)
+
+        # Add separator
+        separator = QFrame()
+        separator.setFrameShape(QFrame.Shape.HLine)
+        separator.setFrameShadow(QFrame.Shadow.Sunken)
+        self.layout.addWidget(separator)
 
         # Add build version at bottom with styling
         self.build_version_label = QLabel(f"Version {__version__}")

--- a/monitor-app/src/gui/utils/app_settings.py
+++ b/monitor-app/src/gui/utils/app_settings.py
@@ -7,7 +7,7 @@ class AppSettings:
     APP_ID = "com." + ORG_NAME
     ORG_DOMAIN = ORG_NAME + ".com"
     ICON_PATH = ":/icons/light/tower-control.svg"
-    VERSION = __version__
+    VERSION = __version__.lstrip('v')
 
     @classmethod
     def set_app_metadata(cls):

--- a/monitor-app/src/version.py
+++ b/monitor-app/src/version.py
@@ -1,5 +1,5 @@
 """Version number for the application."""
 
-VERSION = "0.0.2"
+VERSION = "0.0.3"
 
 __version__ = VERSION


### PR DESCRIPTION
Fixes #76

Add a GitHub update checker to the application.

* Add `version_checker.py` to fetch the latest version from GitHub and compare it with the current version.
* Modify `settings_dialog.py` to display the latest version information and add a button to open the latest release page.
* Modify `main.py` to check for updates on app run and display a subtle notification if an update is available.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bl4ckswordsman/disco-beacon/pull/77?shareId=24137903-48b6-4608-8fc9-4d83722a3bbb).