### PR TITLE
Add workflow for generating release notes and changelog

### DIFF
--- a/.github/workflows/generate_release_notes.yaml
+++ b/.github/workflows/generate_release_notes.yaml
@@ -1,0 +1,39 @@
+name: Generate Release Notes and Changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Release Version'
+        required: true
+      additional_notes:
+        description: 'Additional Notes'
+        required: false
+
+jobs:
+  generate_release_notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate Release Notes
+        id: release_notes
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
+
+      - name: Compile Changelog
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const changelogPath = 'CHANGELOG.md';
+            const releaseNotes = `# Release ${github.event.inputs.release_version}\n\n${steps.release_notes.outputs.draft}\n\n${github.event.inputs.additional_notes || ''}\n\n`;
+            if (fs.existsSync(changelogPath)) {
+              const existingChangelog = fs.readFileSync(changelogPath, 'utf8');
+              fs.writeFileSync(changelogPath, releaseNotes + existingChangelog);
+            } else {
+              fs.writeFileSync(changelogPath, releaseNotes);
+            }
+            console.log('Changelog compiled successfully.');


### PR DESCRIPTION
Fixes #81

Add a new GitHub Actions workflow to generate release notes and changelog.

* **New Workflow File**: Add `.github/workflows/generate_release_notes.yaml` to create a workflow for generating release notes and compiling a changelog.
* **Generate Release Notes**: Use `release-drafter/release-drafter@v5` action to generate release notes from commit messages and PRs.
* **Compile Changelog**: Use `actions/github-script@v6` to compile the generated release notes into a `CHANGELOG.md` file.
* **Manual Trigger**: Configure the workflow to be triggered manually using `workflow_dispatch` with inputs for release version and additional notes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bl4ckswordsman/disco-beacon/pull/82?shareId=0504eee9-0a23-4b04-ab21-91b235201e27).