### PR TITLE
fix: Prevent multiple instances of the application

### DIFF
--- a/monitor-app/src/core/single_instance.py
+++ b/monitor-app/src/core/single_instance.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+if os.name == 'nt':
+    import msvcrt
+else:
+    import fcntl
+
+class SingleInstance:
+    def __init__(self, lockfile):
+        self.lockfile = lockfile
+        self.fp = None
+
+    def __enter__(self):
+        self.fp = open(self.lockfile, 'w')
+        try:
+            if os.name == 'nt':
+                msvcrt.locking(self.fp.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                fcntl.flock(self.fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (IOError, OSError):
+            self.fp.close()
+            return False
+        return True
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        try:
+            if os.name == 'nt':
+                msvcrt.locking(self.fp.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(self.fp, fcntl.LOCK_UN)
+        finally:
+            self.fp.close()
+            os.remove(self.lockfile)

--- a/monitor-app/windows_main.pyw
+++ b/monitor-app/windows_main.pyw
@@ -6,6 +6,12 @@ project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, project_root)
 
 from main import main
+from src.core.single_instance import SingleInstance
+from src.core.logger import logger
 
 if __name__ == "__main__":
-    main()
+    with SingleInstance("/tmp/disco_beacon.lock") as instance:
+        if not instance:
+            logger.error("Another instance of the application is already running.")
+            sys.exit(1)
+        main()


### PR DESCRIPTION
Fixes #83

Add mechanism to prevent multiple instances of the application from running.

* Add `SingleInstance` class in `monitor-app/src/core/single_instance.py` to manage lock file and handle single instance logic.
* Modify `monitor-app/main.py` to import `SingleInstance` class and create an instance at the start of the `main` function.
* Log a message and exit if another instance is already running.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bl4ckswordsman/disco-beacon/pull/84?shareId=8dff641e-bec4-459d-a263-1dbeeacf95ab).